### PR TITLE
docs: direct-to-part writes insted of WAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Storage engine**: Columnar segment format (`.lsg` V2) with delta-varint timestamps, LZ4 compression, dictionary-encoded strings, Gorilla-encoded floats.
 - **Full-text search**: FST-based inverted index with roaring bitmap posting lists and bloom filters for segment skipping.
-- **Write-ahead log (WAL)**: Append-only WAL with configurable sync policy and crash recovery.
+- **Direct-to-part ingest**: `AsyncBatcher` buffers events in memory and flushes immutable `.lsg` parts via atomic rename; configurable `fsync` policy per part write.
 - **Compaction**: Size-tiered compaction (L0 -> L1 -> L2) with rate limiting.
 - **Tiered storage**: Hot (SSD) -> Warm (S3) -> Cold (Glacier) with automatic policy-driven tiering and local segment cache.
 - **SPL2 query language**: Full parser with 20+ commands, 15+ aggregation functions, 20+ eval functions, CTEs, and subsearches.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Follow the same prefixes for commit messages:
 
 ```
 feat: add JOIN command to pipeline
-fix: WAL replay skips corrupted entries instead of panicking
+fix: batcher flush recovers gracefully from interrupted part writes
 chore: update roaring bitmap to v2.4
 ```
 

--- a/cmd/lynxdb/ingest.go
+++ b/cmd/lynxdb/ingest.go
@@ -217,7 +217,7 @@ func printIngestProgress(totalLines int, bytesRead, fileSize int64, start time.T
 
 // reportBatchResult prints a per-batch warning when events were truncated or failed.
 // Truncation means the server's MaxBytesReader cut the request body short.
-// Failures mean events were rejected (e.g., WAL backpressure) but the body was intact.
+// Failures mean events were rejected (e.g., batcher backpressure) but the body was intact.
 func reportBatchResult(result *client.IngestResult, sent, batchNum int) {
 	if result.Truncated {
 		printWarning("Server truncated request body in batch %d: accepted %s of %s events. "+

--- a/docs/site/docs/architecture/design-decisions.md
+++ b/docs/site/docs/architecture/design-decisions.md
@@ -234,6 +234,14 @@ The core tradeoff remains the same: prefer a storage path specialized for immuta
 - Segment writer: columnar encoding + indexing
 - Compaction: merge small segments into large ones
 
+### Why no WAL?
+
+A traditional WAL adds latency to every write (fsync per commit) and complexity to recovery (replay on startup). For log analytics, neither tradeoff is worth it:
+
+- **Latency**: WAL fsyncs serialise ingestion. LynxDB's batcher absorbs bursts and writes parts in bulk, achieving higher throughput with the same disk.
+- **Complexity**: A WAL requires replay logic, truncation handling, and cross-crash consistency guarantees. LynxDB's crash recovery is a simple filesystem scan — delete stale `tmp_*` files and rebuild the registry from surviving `.lsg` parts.
+- **Accepted data window**: Events buffered in the `AsyncBatcher` are in memory and can be lost on crash. This is the same tradeoff [ClickHouse makes](https://github.com/ClickHouse/ClickHouse/issues/64906) — by default, ClickHouse does not fsync after insert, and even with async inserts enabled, `wait_for_async_insert = 0` acknowledges data before it reaches disk. For log workloads, losing the last few seconds of buffered events is an acceptable tradeoff for higher throughput.
+
 ## Related
 
 - [Architecture Overview](/docs/architecture/overview) -- how these decisions manifest in the system

--- a/docs/site/docs/architecture/storage-engine.md
+++ b/docs/site/docs/architecture/storage-engine.md
@@ -56,6 +56,8 @@ Startup recovery is filesystem-driven:
 
 This model has an important durability tradeoff: events accepted into the in-memory batcher are not durable until the part write commits. If the process or host fails before the flush completes, those buffered events can be lost. Clients that need at-least-once delivery should retry on connection loss or other uncertain outcomes.
 
+This is a deliberate design choice, not a bug. LynxDB targets log analytics workloads where losing the last few seconds of buffered events on a crash is an acceptable tradeoff for significantly higher ingest throughput. This is the same tradeoff that [ClickHouse makes by default](https://clickhouse.com/docs/en/operations/settings/settings#async_insert) — inserts write to the OS page cache first, and data in the cache can be lost on power failure. ClickHouse even provides a `wait_for_async_insert = 0` "fire-and-forget" mode where data is acknowledged before it reaches disk, accepting silent data loss in exchange for maximum throughput. LynxDB's `AsyncBatcher` follows the same philosophy: log data is high-volume and append-only, and the cost of a brief data gap on crash is far lower than the cost of synchronously fsync-ing every event.
+
 ## Part Files (`.lsg`)
 
 Parts are the primary storage unit. Each part is a self-contained columnar `.lsg` file with:

--- a/docs/site/docs/configuration/ingest.md
+++ b/docs/site/docs/configuration/ingest.md
@@ -83,7 +83,7 @@ The current ingest path does not write to a WAL. Instead:
 3. the part is optionally `fsync`'d
 4. the file is atomically renamed into place
 
-Events that have been accepted but not yet flushed are not durable.
+Events that have been accepted but not yet flushed are not durable. This is a deliberate tradeoff for log analytics workloads — losing the last few seconds of buffered events on a crash is acceptable in exchange for significantly higher ingest throughput. [ClickHouse follows the same approach](https://clickhouse.com/docs/en/operations/settings/settings#async_insert): by default, inserts are acknowledged after writing to the OS page cache (not disk), and the `wait_for_async_insert = 0` mode even acknowledges before the buffer flush, accepting silent data loss. For at-least-once delivery, enable client-side retries on connection errors.
 
 ### `ingest.fsync`
 

--- a/pkg/api/rest/ingest.go
+++ b/pkg/api/rest/ingest.go
@@ -357,7 +357,7 @@ func (s *Server) processBatched(w http.ResponseWriter, r *http.Request, buildEve
 				continue // pipeline error: skip this batch, try next
 			}
 			if err := s.engine.IngestContext(r.Context(), processed); err != nil {
-				// Retry on WAL backpressure — the ring buffer may drain within
+				// Retry on batcher backpressure — the ring buffer may drain within
 				// one flush cycle (100ms). Three retries at 50ms intervals covers
 				// one full flush cycle, turning transient backpressure into a brief
 				// pause instead of permanent data loss.
@@ -419,7 +419,7 @@ func (s *Server) processBatched(w http.ResponseWriter, r *http.Request, buildEve
 		if err != nil {
 			failed += len(batch)
 		} else if ingestErr := s.engine.IngestContext(r.Context(), processed); ingestErr != nil {
-			// Retry on WAL backpressure (same logic as main loop).
+			// Retry on batcher backpressure (same logic as main loop).
 			retried := false
 			if errors.Is(ingestErr, part.ErrTooManyParts) {
 				for attempt := 0; attempt < 3; attempt++ {

--- a/pkg/cluster/identity.go
+++ b/pkg/cluster/identity.go
@@ -22,7 +22,7 @@ type Role int
 const (
 	// RoleMeta manages cluster metadata via Raft consensus.
 	RoleMeta Role = iota
-	// RoleIngest handles event ingestion and WAL writes.
+	// RoleIngest handles event ingestion and direct-to-part writes.
 	RoleIngest
 	// RoleQuery handles query execution (scatter-gather).
 	RoleQuery

--- a/test/e2e/persistence_test.go
+++ b/test/e2e/persistence_test.go
@@ -11,8 +11,8 @@ import (
 // TestE2E_Persistence_DataSurvivesRestart ingests data to disk, restarts the
 // server, and verifies that all queries return identical results.
 //
-// Regression test for persistence bug (fixed). Verifies memtable flush + WAL
-// recovery preserve all events across restart for multiple indexes.
+// Regression test for persistence bug (fixed). Verifies that batcher flush
+// and atomic part writes preserve all events across restart for multiple indexes.
 func TestE2E_Persistence_DataSurvivesRestart(t *testing.T) {
 	h := NewHarness(t, WithDisk())
 	h.IngestFile("idx_ssh", "testdata/logs/OpenSSH_2k.log")

--- a/test/e2e/testutil_test.go
+++ b/test/e2e/testutil_test.go
@@ -138,9 +138,9 @@ func (h *Harness) stopServer() {
 		h.cancel = nil
 
 		// Wait for srv.Start() to return. Start() blocks on <-shutdownDone
-		// which is closed only after the engine flush + WAL close + registry
-		// sync complete. This guarantees all data is on disk before we
-		// potentially restart the server on the same data directory.
+		// which is closed only after the engine flush + registry sync complete.
+		// This guarantees all data is on disk before we potentially restart
+		// the server on the same data directory.
 		select {
 		case <-h.startDone:
 		case <-time.After(30 * time.Second):


### PR DESCRIPTION
By default, ClickHouse doesn't fsync after INSERT the data is stored in the OS page cache, and if there's a power loss, the last 8-10 minutes of data are lost (SO answer from Denny Crane / ClickHouse team (https://stackoverflow.com/questions/60163070/is-clickhouse-durable))

just would follow this approach in Lynxdb