### PR TITLE
ci: drop deprecated macos-13 runner from sigma nightly matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,7 +270,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The scheduled CI is failing every night. **It is not a test failure** — `conclusion: cancelled`.

Of 16 jobs, 15 pass. Only **`Sigma Compatibility Nightly (macos-13)`** is cancelled, and it has `steps: 0` — it never starts a single step. It sits in the runner queue until GitHub's 24h queue limit auto-cancels it, which cancels the whole run.

This has happened on **every** scheduled run for 1.5+ weeks:

| run | macos-13 job | duration | steps |
|-----|--------------|----------|-------|
| #158 (`25845646273`) | cancelled | ~24h | 0 |
| #140 (`25782592509`) | cancelled | ~24h | 0 |
| #124 (`25717271530`) | cancelled | ~13.5h | 0 |
| #110 (`25593552181`) | cancelled | ~24h | 0 |
| ... #104–#158 | all cancelled | — | 0 |

`macos-13` is GitHub's deprecated Intel macOS image; its runner pool is starved so jobs queue indefinitely. `timeout-minutes` would **not** help — it does not cover queue-wait time.

## Fix

Replace the hard-pinned `macos-13, macos-14` pair with `macos-latest`:

```diff
- os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
+ os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
```

- For a **nightly** job, auto-tracking `macos-latest` is the right tradeoff: the point of the nightly is to catch environment drift, not to rot on a pinned-then-retired image.
- Aligns with `test-unit` / `test-e2e`, which already use `macos-latest`.
- `ubuntu-24.04-arm` kept as-is (no `-latest` alias; only explicit ARM-Linux coverage).
- `TestSigmaCompat` passes on all remaining targets.

## Verification

CI on this PR runs the push/PR-triggered jobs (the nightly matrix is `if: github.event_name == 'schedule'`, so it won't run here). The fix takes effect on the next scheduled run after merge.