### PR TITLE
fix: remove vacuous comment in BSIBuilder.Build

### DIFF
--- a/pkg/storage/segment/index/bsi_builder.go
+++ b/pkg/storage/segment/index/bsi_builder.go
@@ -31,7 +31,6 @@ func (b *BSIBuilder) BitCount() int {
 	return b.bsi.BitCount()
 }
 
-// Build returns the finished BSI.
 func (b *BSIBuilder) Build() *bsi.BSI {
 	return b.bsi
 }


### PR DESCRIPTION
## Summary
- Remove vacuous `// Build returns the finished BSI.` comment flagged by `lint-comm` (`short-vacuous-comment` rule)